### PR TITLE
add pry for debugging awesomeness

### DIFF
--- a/vault-test-tools.gemspec
+++ b/vault-test-tools.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'yard'
   gem.add_dependency 'redcarpet'
   gem.add_dependency 'rr'
+	gem.add_dependency 'pry'
 end


### PR DESCRIPTION
This will allow you to use `pry` for debugging everywhere we use vault-test-tools. Although, you may need to move vault-test-tools into the development group as well to get a handle on it.

Usage:

``` ruby
def buggy_method
binding.pry      # you add this line
foo = 1 * 2 + something_else
end
```

There are lots of advantages to using this over `require 'debug'; debugger`, one of which being that it comes with syntax highlighting and stack frame exploration out of the box. And it seems to work more often.
